### PR TITLE
Return Promise.reject if agent not found

### DIFF
--- a/lib/transport/local/LocalConnection.js
+++ b/lib/transport/local/LocalConnection.js
@@ -33,7 +33,7 @@ function LocalConnection(transport, id, receive) {
 LocalConnection.prototype.send = function (to, message) {
   var callback = this.transport.agents[to];
   if (!callback) {
-    throw new Error('Agent with id ' + to + ' not found');
+    return Promise.reject(new Error('Agent with id ' + to + ' not found'));
   }
 
   // invoke the agents receiver as callback(from, message)


### PR DESCRIPTION
If you send a message to non-existing agent, it will throw an error instead of catching it using ```Promise.catch```.

This patch allows you to chain the ```.send``` function using Promise.